### PR TITLE
Limit multiple gimmicks

### DIFF
--- a/src/battle_indicators.c
+++ b/src/battle_indicators.c
@@ -1927,10 +1927,13 @@ void TryLoadMegaTriggers(void)
 // For Terastallization
 void TryLoadTeraTrigger(void)
 {
-	u8 spriteId, i;
+        u8 spriteId, i;
 
-	if (gBattleTypeFlags & (BATTLE_TYPE_SAFARI | BATTLE_TYPE_POKE_DUDE | BATTLE_TYPE_OLD_MAN))
-		return;
+        if (gBattleTypeFlags & (BATTLE_TYPE_SAFARI | BATTLE_TYPE_POKE_DUDE | BATTLE_TYPE_OLD_MAN))
+                return;
+
+        if (!TerastalEnabled(gActiveBattler))
+                return;
 
 	if (IndexOfSpritePaletteTag(GFX_TAG_TERA_TRIGGER) == 0xFF)
 		LoadSpritePalette(&sTeraTriggerPalette);
@@ -2033,13 +2036,16 @@ static void DestroyZTrigger(struct Sprite* sprite)
 
 void TryLoadDynamaxTrigger(void)
 {
-	u8 spriteId, i;
+        u8 spriteId, i;
 
-	if (gBattleTypeFlags & (BATTLE_TYPE_SAFARI | BATTLE_TYPE_POKE_DUDE | BATTLE_TYPE_OLD_MAN))
-		return;
+        if (gBattleTypeFlags & (BATTLE_TYPE_SAFARI | BATTLE_TYPE_POKE_DUDE | BATTLE_TYPE_OLD_MAN))
+                return;
 
-	if (!(gBattleTypeFlags & BATTLE_TYPE_DYNAMAX))
-		return;
+        if (!(gBattleTypeFlags & BATTLE_TYPE_DYNAMAX))
+                return;
+
+        if (!DynamaxEnabled(gActiveBattler))
+                return;
 
 	if (IndexOfSpritePaletteTag(GFX_TAG_DYNAMAX_TRIGGER) == 0xFF)
 		LoadSpritePalette(&sDynamaxTriggerPalette);

--- a/src/dynamax.c
+++ b/src/dynamax.c
@@ -509,21 +509,30 @@ static item_t FindBankDynamaxBand(u8 bank)
 
 bool8 DynamaxEnabled(u8 bank)
 {
-	if (gBattleTypeFlags & BATTLE_TYPE_DYNAMAX)
-	{
-		if (FindBankDynamaxBand(bank) == ITEM_NONE)
-		{
-			#ifdef DEBUG_DYNAMAX
-				return TRUE;
-			#else
-				return FALSE;
+        if (gBattleTypeFlags & BATTLE_TYPE_DYNAMAX)
+        {
+                if (GetBattlerSide(bank) == B_SIDE_PLAYER)
+                {
+                        if (CanMegaEvolve(bank, FALSE) || CanMegaEvolve(bank, TRUE) || HasMegaSymbol(bank))
+                                return FALSE;
+
+                        if (IsZCrystal(ITEM(bank)))
+                                return FALSE;
+                }
+
+                if (FindBankDynamaxBand(bank) == ITEM_NONE)
+                {
+                        #ifdef DEBUG_DYNAMAX
+                                return TRUE;
+                        #else
+                                return FALSE;
 			#endif
 		}
 
-		return TRUE;
-	}
+                return TRUE;
+        }
 
-	return FALSE;
+        return FALSE;
 }
 
 bool8 HasBankDynamaxedAlready(u8 bank)

--- a/src/move_menu.c
+++ b/src/move_menu.c
@@ -362,11 +362,11 @@ static bool8 TriggerTerastallization(void)
     struct ChooseMoveStruct *moveInfo = (struct ChooseMoveStruct*)(&gBattleBufferA[gActiveBattler][4]);
     u8 side = GetBattlerSide(gActiveBattler);
 
-	if (!CanTerastallize(side) && !TerastalEnabled(side))
-		return FALSE;
+       if (!CanTerastallize(side) || !TerastalEnabled(side))
+               return FALSE;
 	
-    // Retorna FALSE se não puder Terastallizar
-    if (!moveInfo->canTera || moveInfo->canMegaEvolve)
+   // Retorna FALSE se não puder Terastallizar
+   if (!moveInfo->canTera)
         return FALSE;
 
     for (u8 i = 0; i < PARTY_SIZE; i++)

--- a/src/terastallization.c
+++ b/src/terastallization.c
@@ -10,6 +10,7 @@
 #include "../include/battle.h"
 #include "../include/event_data.h"
 #include "../include/item.h"
+#include "../include/new/item.h"
 #include "../include/mgba.h"
 #include "../include/palette.h"
 #include "../include/pokemon.h"
@@ -24,6 +25,7 @@
 #include "../include/new/battle_indicators.h"
 #include "../include/new/battle_script_util.h"
 #include "../include/new/frontier.h"
+#include "../include/new/mega.h"
 #include "../include/new/move_battle_scripts.h"
 #include "../include/new/ram_locs.h"
 #include "../include/new/terastallization.h"
@@ -335,6 +337,16 @@ bool8 TerastalEnabled(u8 bank)
 
     // The rest of the code assumes B_SIDE_PLAYER
     if (!FlagGet(FLAG_TERA_BATTLE))
+        return FALSE;
+
+    // Only one gimmick allowed - Mega and Z take precedence
+    if (CanMegaEvolve(bank, FALSE) || CanMegaEvolve(bank, TRUE) || HasMegaSymbol(bank))
+        return FALSE;
+
+    if (IsZCrystal(ITEM(bank)))
+        return FALSE;
+
+    if (gBattleTypeFlags & BATTLE_TYPE_DYNAMAX)
         return FALSE;
 
     if (FindBankTeraOrb(bank) != ITEM_NONE)


### PR DESCRIPTION
## Summary
- enforce single gimmick usage when Mega or Z-move is available
- disable tera trigger if not allowed
- block Dynamax when Mega or Z–Crystal is present

## Testing
- `make -n` *(fails: no makefile)*

------
https://chatgpt.com/codex/tasks/task_e_686527ae95d083209fd2551063b0b81c