### PR TITLE
Fix Tera + Dynamax toggle ordering

### DIFF
--- a/src/battle_indicators.c
+++ b/src/battle_indicators.c
@@ -895,14 +895,23 @@ static void SpriteCB_MegaTrigger(struct Sprite* self)
 			self->invisible = FALSE;
 	}
 
-	s16 xShift = 0;
-	if (gBattleTypeFlags & BATTLE_TYPE_DOUBLE)
-	{
-		if (GetBattlerPosition(TRIGGER_BANK) == B_POSITION_PLAYER_LEFT)
-			xShift = -48; //X Pos = 16
-		else
-			xShift = 10; //X Pos = 74
-	}
+        s16 xShift = 0;
+        bool8 bothAvailable = (gBattleTypeFlags & BATTLE_TYPE_DYNAMAX)
+                              && DynamaxEnabled(TRIGGER_BANK)
+                              && TerastalEnabled(TRIGGER_BANK);
+
+        if (gBattleTypeFlags & BATTLE_TYPE_DOUBLE)
+        {
+                if (GetBattlerPosition(TRIGGER_BANK) == B_POSITION_PLAYER_LEFT)
+                        xShift = -48; //X Pos = 16
+                else
+                        xShift = 10; //X Pos = 74
+
+                if (bothAvailable)
+                        xShift += 16; //Tera trigger to the right
+        }
+        else if (bothAvailable)
+                xShift = 24; //Right side when both triggers
 
 	self->pos1.x = 64 + (32 / 2);
 	self->pos1.y = 80 + (32 / 2);
@@ -1018,14 +1027,23 @@ static void SpriteCB_TeraTrigger(struct Sprite* self)
 			self->invisible = FALSE;
 	}
 
-	s16 xShift = 0;
-	if (gBattleTypeFlags & BATTLE_TYPE_DOUBLE)
-	{
-		if (GetBattlerPosition(TRIGGER_BANK) == B_POSITION_PLAYER_LEFT)
-			xShift = -48; //X Pos = 16
-		else
-			xShift = 10; //X Pos = 74
-	}
+        s16 xShift = 0;
+        bool8 bothAvailable = (gBattleTypeFlags & BATTLE_TYPE_DYNAMAX)
+                              && DynamaxEnabled(TRIGGER_BANK)
+                              && TerastalEnabled(TRIGGER_BANK);
+
+        if (gBattleTypeFlags & BATTLE_TYPE_DOUBLE)
+        {
+                if (GetBattlerPosition(TRIGGER_BANK) == B_POSITION_PLAYER_LEFT)
+                        xShift = -48; //X Pos = 16
+                else
+                        xShift = 10; //X Pos = 74
+
+                if (bothAvailable)
+                        xShift += 16; //Tera trigger to the right
+        }
+        else if (bothAvailable)
+                xShift = 24; //Right side when both triggers
 
 	self->pos1.x = 64 + (32 / 2);
 	self->pos1.y = 80 + (32 / 2);
@@ -1304,14 +1322,23 @@ static void SpriteCB_ZTrigger(struct Sprite* self)
 
 static void SpriteCB_DynamaxTrigger(struct Sprite* self)
 {
-	s16 xShift = 0;
-	if (gBattleTypeFlags & BATTLE_TYPE_DOUBLE)
-	{
-		if (GetBattlerPosition(TRIGGER_BANK) == B_POSITION_PLAYER_LEFT)
-			xShift = -48; //X Pos = 16
-		else
-			xShift = 10; //X Pos = 74
-	}
+        s16 xShift = 0;
+        bool8 bothAvailable = (gBattleTypeFlags & BATTLE_TYPE_DYNAMAX)
+                              && DynamaxEnabled(TRIGGER_BANK)
+                              && TerastalEnabled(TRIGGER_BANK);
+
+        if (gBattleTypeFlags & BATTLE_TYPE_DOUBLE)
+        {
+                if (GetBattlerPosition(TRIGGER_BANK) == B_POSITION_PLAYER_LEFT)
+                        xShift = -48; //X Pos = 16
+                else
+                        xShift = 10; //X Pos = 74
+
+                if (bothAvailable)
+                        xShift -= 16; //Place Dynamax left of Tera
+        }
+        else if (bothAvailable)
+                xShift = -24; //Single battle left shift
 
 	self->pos1.x = 64 + (32 / 2);
 	self->pos1.y = 80 + (32 / 2);

--- a/src/move_menu.c
+++ b/src/move_menu.c
@@ -298,16 +298,33 @@ void HandleInputChooseMove(void)
     {
         if (!MoveSelectionDisplayZMove()) // Only one special mechanic is allowed at a time
         {
-            if (gNewBS->teraData.chosen[gActiveBattler])
+            if (gBattleTypeFlags & BATTLE_TYPE_DYNAMAX &&
+                DynamaxEnabled(gActiveBattler) &&
+                TerastalEnabled(gActiveBattler))
             {
-                gNewBS->teraData.chosen[gActiveBattler] = FALSE; // Cancel Tera and show Dynamax menu
-                MoveSelectionDisplayMoveEffectiveness();
-
-                if (!TriggerMegaEvolution() && (gBattleTypeFlags & BATTLE_TYPE_DYNAMAX))
+                if (gNewBS->teraData.chosen[gActiveBattler])
+                {
+                    gNewBS->teraData.chosen[gActiveBattler] = FALSE; // Deactivate both
+                    MoveSelectionDisplayMoveEffectiveness();
+                }
+                else if (gNewBS->dynamaxData.viewing)
+                {
+                    CloseMaxMoveDetails();            // Deactivate Dynamax
+                    TriggerTerastallization();        // Activate Tera
+                }
+                else if (!TriggerMegaEvolution())       // Activate Dynamax
                     MoveSelectionDisplayMaxMove();
             }
-            else if (!TriggerTerastallization() && (!TriggerMegaEvolution() && (gBattleTypeFlags & BATTLE_TYPE_DYNAMAX)))
-                MoveSelectionDisplayMaxMove();
+            else // Original behaviour
+            {
+                if (gNewBS->teraData.chosen[gActiveBattler])
+                {
+                    gNewBS->teraData.chosen[gActiveBattler] = FALSE;
+                    MoveSelectionDisplayMoveEffectiveness();
+                }
+                else if (!TriggerTerastallization() && (!TriggerMegaEvolution() && (gBattleTypeFlags & BATTLE_TYPE_DYNAMAX)))
+                    MoveSelectionDisplayMaxMove();
+            }
         }
     }
 	else if (gMain.newKeys & L_BUTTON)


### PR DESCRIPTION
## Summary
- adjust the in‑battle toggle flow so Dynamax and Tera cycle correctly
- offset trigger sprites when both gimmicks are available

## Testing
- `python scripts/make.py` *(fails: could not find source rom)*

------
https://chatgpt.com/codex/tasks/task_e_6867764fded88320acb45e7955283061