### PR TITLE
Fix DexNav header collisions

### DIFF
--- a/include/new/dexnav_data.h
+++ b/include/new/dexnav_data.h
@@ -2,6 +2,14 @@
 
 #include "../global.h"
 
+#ifndef CONTEXT_MENU_MOVE_CURSOR_FUNC
+#define CONTEXT_MENU_MOVE_CURSOR_FUNC NULL
+#endif
+
+#ifndef CONTEXT_MENU_ITEM_PRINT_FUNC
+#define CONTEXT_MENU_ITEM_PRINT_FUNC NULL
+#endif
+
 /**
  * \file dns_data.h
  * \brief A file to be included only by "src/dexnav.c". It contains declarations,
@@ -193,12 +201,12 @@ enum EncounterTypes
 	ENCOUNTER_METHOD_COUNT,
 };
 
-enum BGs
+enum DexNavBGs
 {
-	BG_TEXTBOX,
-	BG_TEXT_2,
-	BG_TEXT,
-	BG_BACKGROUND,
+        DEXNAV_BG_TEXTBOX,
+        DEXNAV_BG_TEXT_2,
+        DEXNAV_BG_TEXT,
+        DEXNAV_BG_BACKGROUND,
 };
 
 enum
@@ -223,7 +231,7 @@ static const struct WindowTemplate sDexNavWinTemplates[WINDOW_COUNT + 1] =
 {
 	[WIN_TEXTBOX] =
 	{
-		.bg = BG_TEXTBOX,
+		.bg = DEXNAV_BG_TEXTBOX,
 		.tilemapLeft = 1,
 		.tilemapTop = 15,
 		.width = 28,
@@ -233,7 +241,7 @@ static const struct WindowTemplate sDexNavWinTemplates[WINDOW_COUNT + 1] =
 	},
 	[WIN_CONTEXT_MENU] =
 	{
-		.bg = BG_TEXTBOX,
+		.bg = DEXNAV_BG_TEXTBOX,
 		.tilemapLeft = 21,
 		.tilemapTop = 7,
 		.width = 7,
@@ -243,7 +251,7 @@ static const struct WindowTemplate sDexNavWinTemplates[WINDOW_COUNT + 1] =
 	},
 	[WIN_SPECIES] =
 	{
-		.bg = BG_TEXT_2, //Above so it doesn't conflict with the type icons
+		.bg = DEXNAV_BG_TEXT_2, //Above so it doesn't conflict with the type icons
 		.tilemapLeft = 20,
 		.tilemapTop = 2,
 		.width = 9,
@@ -253,7 +261,7 @@ static const struct WindowTemplate sDexNavWinTemplates[WINDOW_COUNT + 1] =
 	},
 	[WIN_SEARCH_LEVEL] =
 	{
-		.bg = BG_TEXT,
+		.bg = DEXNAV_BG_TEXT,
 		.tilemapLeft = 20,
 		.tilemapTop = 7,
 		.width = 9,
@@ -263,7 +271,7 @@ static const struct WindowTemplate sDexNavWinTemplates[WINDOW_COUNT + 1] =
 	},
 	[WIN_METHOD] =
 	{
-		.bg = BG_TEXT,
+		.bg = DEXNAV_BG_TEXT,
 		.tilemapLeft = 20,
 		.tilemapTop = 10,
 		.width = 10,
@@ -273,7 +281,7 @@ static const struct WindowTemplate sDexNavWinTemplates[WINDOW_COUNT + 1] =
 	},
 	[WIN_HIDDEN_ABILITY] =
 	{
-		.bg = BG_TEXT,
+		.bg = DEXNAV_BG_TEXT,
 		.tilemapLeft = 20,
 		.tilemapTop = 13,
 		.width = 10,
@@ -283,7 +291,7 @@ static const struct WindowTemplate sDexNavWinTemplates[WINDOW_COUNT + 1] =
 	},
 	[WIN_HELD_ITEMS] =
 	{
-		.bg = BG_TEXT,
+		.bg = DEXNAV_BG_TEXT,
 		.tilemapLeft = 20,
 		.tilemapTop = 16,
 		.width = 10,
@@ -293,7 +301,7 @@ static const struct WindowTemplate sDexNavWinTemplates[WINDOW_COUNT + 1] =
 	},
 	[WIN_MON_TYPE_1] =
 	{
-		.bg = BG_TEXT,
+		.bg = DEXNAV_BG_TEXT,
 		.tilemapLeft = 20,
 		.tilemapTop = 4,
 		.width = 5,
@@ -303,7 +311,7 @@ static const struct WindowTemplate sDexNavWinTemplates[WINDOW_COUNT + 1] =
 	},
 	[WIN_MON_TYPE_2] =
 	{
-		.bg = BG_TEXT,
+		.bg = DEXNAV_BG_TEXT,
 		.tilemapLeft = 25,
 		.tilemapTop = 4,
 		.width = 5,
@@ -313,7 +321,7 @@ static const struct WindowTemplate sDexNavWinTemplates[WINDOW_COUNT + 1] =
 	},
 	[WIN_WATER] =
 	{
-		.bg = BG_TEXT,
+		.bg = DEXNAV_BG_TEXT,
 		.tilemapLeft = 0,
 		.tilemapTop = 2,
 		.width = 19,
@@ -323,7 +331,7 @@ static const struct WindowTemplate sDexNavWinTemplates[WINDOW_COUNT + 1] =
 	},
 	[WIN_LAND] =
 	{
-		.bg = BG_TEXT,
+		.bg = DEXNAV_BG_TEXT,
 		.tilemapLeft = 0,
 	#ifdef UNBOUND
 		.tilemapTop = 10,
@@ -337,7 +345,7 @@ static const struct WindowTemplate sDexNavWinTemplates[WINDOW_COUNT + 1] =
 	},
 	[WIN_MAP_NAME] =
 	{
-		.bg = BG_TEXT,
+		.bg = DEXNAV_BG_TEXT,
 		.tilemapLeft = 0,
 		.tilemapTop = 0,
 		.width = 12,
@@ -347,7 +355,7 @@ static const struct WindowTemplate sDexNavWinTemplates[WINDOW_COUNT + 1] =
 	},
 	[WIN_CHAIN_LENGTH] =
 	{
-		.bg = BG_TEXT,
+		.bg = DEXNAV_BG_TEXT,
 		.tilemapLeft = 22,
 		.tilemapTop = 0,
 		.width = 8,
@@ -361,9 +369,9 @@ static const struct WindowTemplate sDexNavWinTemplates[WINDOW_COUNT + 1] =
 
 static const struct BgTemplate sDexNavBgTemplates[] =
 {
-	[BG_TEXTBOX] =
+	[DEXNAV_BG_TEXTBOX] =
 	{
-		.bg = BG_TEXTBOX,
+		.bg = DEXNAV_BG_TEXTBOX,
 		.charBaseIndex = 0,
 		.mapBaseIndex = 31,
 		.screenSize = 0,
@@ -371,9 +379,9 @@ static const struct BgTemplate sDexNavBgTemplates[] =
 		.priority = 0,
 		.baseTile = 0,
 	},
-	[BG_TEXT_2] =
+	[DEXNAV_BG_TEXT_2] =
 	{
-		.bg = BG_TEXT_2,
+		.bg = DEXNAV_BG_TEXT_2,
 		.charBaseIndex = 1,
 		.mapBaseIndex = 30,
 		.screenSize = 0,
@@ -381,9 +389,9 @@ static const struct BgTemplate sDexNavBgTemplates[] =
 		.priority = 1,
 		.baseTile = 0,
 	},
-	[BG_TEXT] =
+	[DEXNAV_BG_TEXT] =
 	{
-		.bg = BG_TEXT,
+		.bg = DEXNAV_BG_TEXT,
 		.charBaseIndex = 2,
 		.mapBaseIndex = 29,
 		.screenSize = 0,
@@ -391,9 +399,9 @@ static const struct BgTemplate sDexNavBgTemplates[] =
 		.priority = 2,
 		.baseTile = 0,
 	},
-	[BG_BACKGROUND] =
+	[DEXNAV_BG_BACKGROUND] =
 	{
-		.bg = BG_BACKGROUND,
+		.bg = DEXNAV_BG_BACKGROUND,
 		.charBaseIndex = 3,
 		.mapBaseIndex = 28,
 		.screenSize = 0,
@@ -412,10 +420,10 @@ static const struct ListMenuItem sContextMenuListItems[] =
 
 static const struct ListMenuTemplate sContextMenuTemplate =
 {
-	.items = sContextMenuListItems,
-	.totalItems = 3, //Register, Scan, Close
-	.moveCursorFunc = ContextMenuMoveCursorFunc,
-	.itemPrintFunc = ContextMenuItemPrintFunc,
+        .items = sContextMenuListItems,
+        .totalItems = 3, //Register, Scan, Close
+        .moveCursorFunc = CONTEXT_MENU_MOVE_CURSOR_FUNC,
+        .itemPrintFunc = CONTEXT_MENU_ITEM_PRINT_FUNC,
 
 	.windowId = WIN_CONTEXT_MENU,
 	.header_X = 0,

--- a/src/dexnav.c
+++ b/src/dexnav.c
@@ -196,7 +196,11 @@ static void ClearTasksAndGraphicalStructs(void);
 static void ClearVramOamPlttRegs(void);
 static void CB2_DexNav(void);
 
+#define CONTEXT_MENU_MOVE_CURSOR_FUNC ContextMenuMoveCursorFunc
+#define CONTEXT_MENU_ITEM_PRINT_FUNC ContextMenuItemPrintFunc
 #include "../include/new/dexnav_data.h"
+#undef CONTEXT_MENU_MOVE_CURSOR_FUNC
+#undef CONTEXT_MENU_ITEM_PRINT_FUNC
 
 
 // ===================================== //
@@ -2456,7 +2460,7 @@ static void PrintDexNavMessage(u8 messageId)
 	if (sDexNavGUIPtr->cursorSpriteId < MAX_SPRITES)
 		StartSpriteAnim(&gSprites[sDexNavGUIPtr->cursorSpriteId], 1); //Pointing and unmoving
 
-	ShowBg(BG_TEXTBOX);
+	ShowBg(DEXNAV_BG_TEXTBOX);
 }
 
 static void PrintDexNavError(u8 taskId, u8 specificMsgId)
@@ -2506,7 +2510,7 @@ static void HideDexNavMessage(void)
 	if (sDexNavGUIPtr->cursorSpriteId < MAX_SPRITES)
 		StartSpriteAnim(&gSprites[sDexNavGUIPtr->cursorSpriteId], 0); //Moving
 
-	HideBg(BG_TEXTBOX);
+	HideBg(DEXNAV_BG_TEXTBOX);
 }
 
 static void ContextMenuMoveCursorFunc(unusedArg s32 listIndex, bool8 onInit, unusedArg struct ListMenu* list)
@@ -3680,7 +3684,7 @@ static void LoadDexNavBgGfx(void)
 	palette = DexNavBGPal;
 	#endif
 
-	decompress_and_copy_tile_data_to_vram(BG_BACKGROUND, tiles, 0, 0, 0);
+	decompress_and_copy_tile_data_to_vram(DEXNAV_BG_BACKGROUND, tiles, 0, 0, 0);
 	LZDecompressWram(map, sDexNavGUIPtr->tilemapPtr);
 
 	//Choose palette based on current location
@@ -3766,7 +3770,7 @@ static void CB2_DexNav(void)
 			sDexNavGUIPtr->tilemapPtr = Malloc(0x1000);
 			ResetBgsAndClearDma3BusyFlags(0);
 			InitBgsFromTemplates(0, sDexNavBgTemplates, NELEMS(sDexNavBgTemplates));
-			SetBgTilemapBuffer(BG_BACKGROUND, sDexNavGUIPtr->tilemapPtr);
+			SetBgTilemapBuffer(DEXNAV_BG_BACKGROUND, sDexNavGUIPtr->tilemapPtr);
 			gMain.state++;
 			break;
 		case 3:
@@ -3776,10 +3780,10 @@ static void CB2_DexNav(void)
 		case 4:
 			if (!free_temp_tile_data_buffers_if_possible())
 			{
-				ShowBg(BG_TEXT);
-				ShowBg(BG_TEXT_2);
-				ShowBg(BG_BACKGROUND);
-				CopyBgTilemapBufferToVram(BG_BACKGROUND);
+				ShowBg(DEXNAV_BG_TEXT);
+				ShowBg(DEXNAV_BG_TEXT_2);
+				ShowBg(DEXNAV_BG_BACKGROUND);
+				CopyBgTilemapBufferToVram(DEXNAV_BG_BACKGROUND);
 				gMain.state++;
 			}
 			break;


### PR DESCRIPTION
## Summary
- avoid collisions by namespacing DexNav background enum values
- allow other translation units to include `dexnav_data.h`
  by providing default `NULL` handlers for context menu callbacks
- update DexNav to set macros before including the header

## Testing
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_6880e9b49134832085b2e1d358a4d43b