### PR TITLE
Optimize album text scrolling

### DIFF
--- a/include/new/album.h
+++ b/include/new/album.h
@@ -46,6 +46,9 @@ struct Album
     // Tracker Data
     u8 selectedMemory;
     u8 selectedMemoryInAlbum; // Max of 7
+
+    // Index of the first memory currently shown
+    u8 displayedStartId;
 };
 
 static const struct TextColor sWhiteText =

--- a/include/new/album.h
+++ b/include/new/album.h
@@ -2,14 +2,21 @@
 
 #include "../global.h"
 
-#define MEMORIES_COUNT 9
+#define MEMORIES_COUNT 44
 #define sAlbumPtr (*((struct Album**) 0x203E038))
 #define BG_MAP_BYTES 0x800
 #define ALBUM_MEMORIES_PER_PAGE 7
+#define FLAG_SYS_DEXNAV 0x91E
 
 #define VAR_ALBUM_SELECTED_MEMORY_IN_ALBUM 0x5100
 #define VAR_ALBUM_SELECTED_MEMORY 0x5101
 #define VAR_ALBUM_FIRST_TIME 0x5012
+
+#define FLAG_ALBUM_GET 0x15FF
+#define FLAG_FIRST_MEMORY 0x1600
+#define FLAG_ALBUM_LAST_MEMORY 0x1625
+
+extern bool8 StartMenuAlbumCallback(void);
 
 enum AlbumWindows
 {
@@ -46,9 +53,7 @@ struct Album
     // Tracker Data
     u8 selectedMemory;
     u8 selectedMemoryInAlbum; // Max of 7
-
-    // Index of the first memory currently shown
-    u8 displayedStartId;
+    u8 displayedStartId; // Start ID for the displayed memories
 };
 
 static const struct TextColor sWhiteText =
@@ -67,29 +72,96 @@ extern const u16 AlbumBGPal[];
 extern const u8 gText_AlbumHeader[];
 
 // Memory Names
-extern const u8 gText_Memory_MeloettaUnderTree[];
-extern const u8 gText_Memory_PikachuAndEevee[];
-extern const u8 gText_Memory_InsideCave[];
-extern const u8 gText_Memory_NightSkyWish[];
-extern const u8 gText_Memory_SeasideShells[];
-extern const u8 gText_Memory_CampfireTales[];
-extern const u8 gText_Memory_SakuraPath[];
-extern const u8 gText_Memory_SnowballFight[];
-extern const u8 gText_Memory_LabDiscovery[];
+extern const u8 gText_None[];
+extern const u8 gText_Memory_1[];
+extern const u8 gText_Memory_2[];
+extern const u8 gText_Memory_3[];
+extern const u8 gText_Memory_4[];
+extern const u8 gText_Memory_5[];
+extern const u8 gText_Memory_6[];
+extern const u8 gText_Memory_7[];
+extern const u8 gText_Memory_8[];
+extern const u8 gText_Memory_9[];
+extern const u8 gText_Memory_10[];
+extern const u8 gText_Memory_11[];
+extern const u8 gText_Memory_12[];
+extern const u8 gText_Memory_13[];
+extern const u8 gText_Memory_14[];
+extern const u8 gText_Memory_15[];
+extern const u8 gText_Memory_16[];
+extern const u8 gText_Memory_17[];
+extern const u8 gText_Memory_18[];
+extern const u8 gText_Memory_19[];
+extern const u8 gText_Memory_20[];
+extern const u8 gText_Memory_21[];
+extern const u8 gText_Memory_22[];
+extern const u8 gText_Memory_23[];
+extern const u8 gText_Memory_24[];
+extern const u8 gText_Memory_25[];
+extern const u8 gText_Memory_26[];
+extern const u8 gText_Memory_27[];
+extern const u8 gText_Memory_28[];
+extern const u8 gText_Memory_29[];
+extern const u8 gText_Memory_30[];
+extern const u8 gText_Memory_31[];
+extern const u8 gText_Memory_32[];
+extern const u8 gText_Memory_33[];
+extern const u8 gText_Memory_34[];
+extern const u8 gText_Memory_35[];
+extern const u8 gText_Memory_36[];
+extern const u8 gText_Memory_37[];
+extern const u8 gText_Memory_38[];
+extern const u8 gText_Memory_39[];
+extern const u8 gText_Memory_40[];
+extern const u8 gText_Memory_41[];
+extern const u8 gText_Memory_42[];
+extern const u8 gText_Memory_43[];
 
 // Memory Descriptions
-extern const u8 gText_MemoryDesc_MeloettaUnderTree[];
-extern const u8 gText_MemoryDesc_PikachuAndEevee[];
-extern const u8 gText_MemoryDesc_InsideCave[];
-extern const u8 gText_MemoryDesc_NightSkyWish[];
-extern const u8 gText_MemoryDesc_SeasideShells[];
-extern const u8 gText_MemoryDesc_CampfireTales[];
-extern const u8 gText_MemoryDesc_SakuraPath[];
-extern const u8 gText_MemoryDesc_SnowballFight[];
-extern const u8 gText_MemoryDesc_LabDiscovery[];
-
-// Script call
-extern const u8 EventScript_AlbumMemorySelected[];
+extern const u8 gText_Desc_None[];
+extern const u8 gText_MemoryDesc_1[];
+extern const u8 gText_MemoryDesc_2[];
+extern const u8 gText_MemoryDesc_3[];
+extern const u8 gText_MemoryDesc_4[];
+extern const u8 gText_MemoryDesc_5[];
+extern const u8 gText_MemoryDesc_6[];
+extern const u8 gText_MemoryDesc_7[];
+extern const u8 gText_MemoryDesc_8[];
+extern const u8 gText_MemoryDesc_9[];
+extern const u8 gText_MemoryDesc_10[];
+extern const u8 gText_MemoryDesc_11[];
+extern const u8 gText_MemoryDesc_12[];
+extern const u8 gText_MemoryDesc_13[];
+extern const u8 gText_MemoryDesc_14[];
+extern const u8 gText_MemoryDesc_15[];
+extern const u8 gText_MemoryDesc_16[];
+extern const u8 gText_MemoryDesc_17[];
+extern const u8 gText_MemoryDesc_18[];
+extern const u8 gText_MemoryDesc_19[];
+extern const u8 gText_MemoryDesc_20[];
+extern const u8 gText_MemoryDesc_21[];
+extern const u8 gText_MemoryDesc_22[];
+extern const u8 gText_MemoryDesc_23[];
+extern const u8 gText_MemoryDesc_24[];
+extern const u8 gText_MemoryDesc_25[];
+extern const u8 gText_MemoryDesc_26[];
+extern const u8 gText_MemoryDesc_27[];
+extern const u8 gText_MemoryDesc_28[];
+extern const u8 gText_MemoryDesc_29[];
+extern const u8 gText_MemoryDesc_30[];
+extern const u8 gText_MemoryDesc_31[];
+extern const u8 gText_MemoryDesc_32[];
+extern const u8 gText_MemoryDesc_33[];
+extern const u8 gText_MemoryDesc_34[];
+extern const u8 gText_MemoryDesc_35[];
+extern const u8 gText_MemoryDesc_36[];
+extern const u8 gText_MemoryDesc_37[];
+extern const u8 gText_MemoryDesc_38[];
+extern const u8 gText_MemoryDesc_39[];
+extern const u8 gText_MemoryDesc_40[];
+extern const u8 gText_MemoryDesc_41[];
+extern const u8 gText_MemoryDesc_42[];
+extern const u8 gText_MemoryDesc_43[];
 
 struct ImageData 
 {
@@ -98,5 +170,5 @@ struct ImageData
     u16 *pal;
 };
 
-#define ImageDataTable ((const struct ImageData *) 0x8FE4E80)
+#define ImageDataTable ((const struct ImageData *) 0x90B7600)
 #define tilemapbuffer (*((u8**) 0x203E038))

--- a/src/album.c
+++ b/src/album.c
@@ -143,34 +143,117 @@ static const struct WindowTemplate sAlbumWinTemplates[WIN_MAX_COUNT + 1] =
     DUMMY_WIN_TEMPLATE,
 };
 
+static const u8 *const sMemoryNames[] =
+{
+    gText_None,
+    gText_Memory_1,
+    gText_Memory_2,
+    gText_Memory_3,
+    gText_Memory_4,
+    gText_Memory_5,
+    gText_Memory_6,
+    gText_Memory_7,
+    gText_Memory_8,
+    gText_Memory_9,
+    gText_Memory_10,
+    gText_Memory_11,
+    gText_Memory_12,
+    gText_Memory_13,
+    gText_Memory_14,
+    gText_Memory_15,
+    gText_Memory_16,
+    gText_Memory_17,
+    gText_Memory_18,
+    gText_Memory_19,
+    gText_Memory_20,
+    gText_Memory_21,
+    gText_Memory_22,
+    gText_Memory_23,
+    gText_Memory_24,
+    gText_Memory_25,
+    gText_Memory_26,
+    gText_Memory_27,
+    gText_Memory_28,
+    gText_Memory_29,
+    gText_Memory_30,
+    gText_Memory_31,
+    gText_Memory_32,
+    gText_Memory_33,
+    gText_Memory_34,
+    gText_Memory_35,
+    gText_Memory_36,
+    gText_Memory_37,
+    gText_Memory_38,
+    gText_Memory_39,
+    gText_Memory_40,
+    gText_Memory_41,
+    gText_Memory_42,
+    gText_Memory_43,
+};
+
+static const u8 *const sMemoryDescs[] =
+{
+    gText_Desc_None,
+    gText_MemoryDesc_1,
+    gText_MemoryDesc_2,
+    gText_MemoryDesc_3,
+    gText_MemoryDesc_4,
+    gText_MemoryDesc_5,
+    gText_MemoryDesc_6,
+    gText_MemoryDesc_7,
+    gText_MemoryDesc_8,
+    gText_MemoryDesc_9,
+    gText_MemoryDesc_10,
+    gText_MemoryDesc_11,
+    gText_MemoryDesc_12,
+    gText_MemoryDesc_13,
+    gText_MemoryDesc_14,
+    gText_MemoryDesc_15,
+    gText_MemoryDesc_16,
+    gText_MemoryDesc_17,
+    gText_MemoryDesc_18,
+    gText_MemoryDesc_19,
+    gText_MemoryDesc_20,
+    gText_MemoryDesc_21,
+    gText_MemoryDesc_22,
+    gText_MemoryDesc_23,
+    gText_MemoryDesc_24,
+    gText_MemoryDesc_25,
+    gText_MemoryDesc_26,
+    gText_MemoryDesc_27,
+    gText_MemoryDesc_28,
+    gText_MemoryDesc_29,
+    gText_MemoryDesc_30,
+    gText_MemoryDesc_31,
+    gText_MemoryDesc_32,
+    gText_MemoryDesc_33,
+    gText_MemoryDesc_34,
+    gText_MemoryDesc_35,
+    gText_MemoryDesc_36,
+    gText_MemoryDesc_37,
+    gText_MemoryDesc_38,
+    gText_MemoryDesc_39,
+    gText_MemoryDesc_40,
+    gText_MemoryDesc_41,
+    gText_MemoryDesc_42,
+    gText_MemoryDesc_43,
+};
+
 static void InitAlbumData(void)
 {
-    sAlbumPtr->memoryData[0].memoryName = gText_Memory_MeloettaUnderTree;
-    sAlbumPtr->memoryData[0].memoryDesc = gText_MemoryDesc_MeloettaUnderTree;
+    for (u8 i = 0; i < MEMORIES_COUNT; ++i)
+    {
+        sAlbumPtr->memoryData[i].memoryName = sMemoryNames[i];
+        sAlbumPtr->memoryData[i].memoryDesc = sMemoryDescs[i];
 
-    sAlbumPtr->memoryData[1].memoryName = gText_Memory_PikachuAndEevee;
-    sAlbumPtr->memoryData[1].memoryDesc = gText_MemoryDesc_PikachuAndEevee;
+        sAlbumPtr->memoryData[i].unlocked = FlagGet(FLAG_FIRST_MEMORY + i);
 
-    sAlbumPtr->memoryData[2].memoryName = gText_Memory_InsideCave;
-    sAlbumPtr->memoryData[2].memoryDesc = gText_MemoryDesc_InsideCave;
-
-    sAlbumPtr->memoryData[3].memoryName = gText_Memory_NightSkyWish;
-    sAlbumPtr->memoryData[3].memoryDesc = gText_MemoryDesc_NightSkyWish;
-
-    sAlbumPtr->memoryData[4].memoryName = gText_Memory_SeasideShells;
-    sAlbumPtr->memoryData[4].memoryDesc = gText_MemoryDesc_SeasideShells;
-
-    sAlbumPtr->memoryData[5].memoryName = gText_Memory_CampfireTales;
-    sAlbumPtr->memoryData[5].memoryDesc = gText_MemoryDesc_CampfireTales;
-
-    sAlbumPtr->memoryData[6].memoryName = gText_Memory_SakuraPath;
-    sAlbumPtr->memoryData[6].memoryDesc = gText_MemoryDesc_SakuraPath;
-
-    sAlbumPtr->memoryData[7].memoryName = gText_Memory_SnowballFight;
-    sAlbumPtr->memoryData[7].memoryDesc = gText_MemoryDesc_SnowballFight;
-
-    sAlbumPtr->memoryData[8].memoryName = gText_Memory_LabDiscovery;
-    sAlbumPtr->memoryData[8].memoryDesc = gText_MemoryDesc_LabDiscovery;
+        if (!sAlbumPtr->memoryData[i].unlocked)
+        {
+            sAlbumPtr->memoryData[i].memoryName = gText_None;
+            sAlbumPtr->memoryData[i].memoryDesc = gText_Desc_None;
+        }
+    }
 }
 
 static void DisplayAlbumBG(void)
@@ -299,7 +382,7 @@ static void Task_AlbumFadeOut(u8 taskId)
 {
     if (!gPaletteFade->active)
     {
-        SetMainCallback2(CB2_ReturnToFieldContinueScript);
+        SetMainCallback2(CB2_ReturnToFieldWithOpenMenu);
         Free(sAlbumPtr->bgMap);
         Free(sAlbumPtr);
         sAlbumPtr = NULL;
@@ -323,7 +406,7 @@ static void Task_AlbumWaitForKeyPress(u8 taskId)
     bool8 redrawNames = FALSE;
     u8 prevStartId = sAlbumPtr->displayedStartId;
 
-    if (gMain.newKeys & DPAD_DOWN)
+    if (JOY_NEW_AND_REPEATED(DPAD_DOWN))
     {
         if (sAlbumPtr->selectedMemory < MEMORIES_COUNT - 1)
         {
@@ -339,7 +422,7 @@ static void Task_AlbumWaitForKeyPress(u8 taskId)
             scrolled = TRUE;
         }
     }
-    else if (gMain.newKeys & DPAD_UP)
+    else if (JOY_NEW_AND_REPEATED(DPAD_UP))
     {
         if (sAlbumPtr->selectedMemory > 0)
         {
@@ -373,11 +456,15 @@ static void Task_AlbumWaitForKeyPress(u8 taskId)
 
     if (gMain.newKeys & A_BUTTON)
     {
-        PlaySE(SE_SELECT);
         VarSet(VAR_ALBUM_SELECTED_MEMORY, sAlbumPtr->selectedMemory);
         VarSet(VAR_ALBUM_SELECTED_MEMORY_IN_ALBUM, sAlbumPtr->selectedMemoryInAlbum);
-        BeginNormalPaletteFade(0xFFFFFFFF, 0, 0, 16, RGB_BLACK);
-        gTasks[taskId].func = Task_AlbumShowImage;
+
+        if (sAlbumPtr->memoryData[sAlbumPtr->selectedMemory].unlocked)
+        {
+            BeginNormalPaletteFade(0xFFFFFFFF, 0, 0, 16, RGB_BLACK);
+            PlaySE(SE_SELECT);
+            gTasks[taskId].func = Task_AlbumShowImage;
+        }
     }
 
     if (gMain.newKeys & B_BUTTON)
@@ -478,7 +565,7 @@ static void CB2_Album(void)
     }
 }
 
-bool8 AlbumCallback(void)
+bool8 StartMenuAlbumCallback(void)
 {
     if (!gPaletteFade->active)
     {
@@ -490,7 +577,6 @@ bool8 AlbumCallback(void)
         SetMainCallback2(CB2_Album);
         return TRUE;
     }
-
     return FALSE;
 }
 
@@ -540,7 +626,6 @@ static void LoadAlbumImage(u8 memoryId)
     LZDecompressWram(image->tilemap, tilemapbuffer);
     LoadPalette(image->pal, 0, 0x20);
 }
-
 
 static void VBlankCB_Image(void)
 {

--- a/src/album.c
+++ b/src/album.c
@@ -203,8 +203,7 @@ static void PrintGUIAlbumMemoryNames(void)
 {
     u8 fontSize = 1; // Normal Text
     u8 y = 0;
-
-    u8 startId = sAlbumPtr->selectedMemory - sAlbumPtr->selectedMemoryInAlbum;
+    u8 startId = sAlbumPtr->displayedStartId;
 
     CleanWindow(WIN_ALBUM_MEMORY_NAME);
 
@@ -321,6 +320,8 @@ static void Task_AlbumShowImage(u8 taskId)
 static void Task_AlbumWaitForKeyPress(u8 taskId)
 {
     bool8 scrolled = FALSE;
+    bool8 redrawNames = FALSE;
+    u8 prevStartId = sAlbumPtr->displayedStartId;
 
     if (gMain.newKeys & DPAD_DOWN)
     {
@@ -354,10 +355,18 @@ static void Task_AlbumWaitForKeyPress(u8 taskId)
         }
     }
 
-    // Update the names and descriptions
     if (scrolled)
     {
-        PrintGUIAlbumMemoryNames();
+        u8 newStartId = sAlbumPtr->selectedMemory - sAlbumPtr->selectedMemoryInAlbum;
+        if (newStartId != prevStartId)
+        {
+            sAlbumPtr->displayedStartId = newStartId;
+            redrawNames = TRUE;
+        }
+
+        if (redrawNames)
+            PrintGUIAlbumMemoryNames();
+
         PrintGUIAlbumDescription();
         PlaySE(SE_SELECT);
     }
@@ -406,6 +415,8 @@ static void InitAlbum(void)
     // Restore the last selected memory and cursor position
     sAlbumPtr->selectedMemory = VarGet(VAR_ALBUM_SELECTED_MEMORY);
     sAlbumPtr->selectedMemoryInAlbum = VarGet(VAR_ALBUM_SELECTED_MEMORY_IN_ALBUM);
+
+    sAlbumPtr->displayedStartId = sAlbumPtr->selectedMemory - sAlbumPtr->selectedMemoryInAlbum;
 
     InitAlbumData();
     PrintGUIAlbumItems();

--- a/strings/album_strings.string
+++ b/strings/album_strings.string
@@ -1,59 +1,289 @@
 #org @gText_AlbumHeader
 Memories
 
+#org @gText_MenuAlbum
+Album
+
+#org @gText_MenuDexNav
+DexNav
+
+#org @gText_MenuExitRight
+Exit  [DPAD_RIGHT]
+
+#org @gText_MenuExitLeft
+Exit  [DPAD_LEFT]
+
+#org @gText_DexNavDescription
+Search for wild Pok\emon in the area\nwith potential special qualities!
+
+#org @gText_AlbumDescription
+A lovely album capturing your journey\nwith Meloetta.
 
 // Memory Names
-#org @gText_Memory_MeloettaUnderTree
-Meloetta under the tree[.]
+#org @gText_None
+-
 
-#org @gText_Memory_PikachuAndEevee
-Pikachu and Eevee!
+#org @gText_Memory_1
+Choose your Kanto starter!
 
-#org @gText_Memory_InsideCave
-Inside Mt. Moon[.]
+#org @gText_Memory_2
+A Pok\ePark Cadence
 
-#org @gText_Memory_NightSkyWish
+#org @gText_Memory_3
+Ballad by the Sunset Bay
+
+#org @gText_Memory_4
 Wishing under the stars[.]
 
-#org @gText_Memory_SeasideShells
+#org @gText_Memory_5
 Shells by the seaside
 
-#org @gText_Memory_CampfireTales
+#org @gText_Memory_6
 Campfire stories[.]
 
-#org @gText_Memory_SakuraPath
-Path of Blossoms
+#org @gText_Memory_7
+Where the leaves first fell
 
-#org @gText_Memory_SnowballFight
+#org @gText_Memory_8
 Snowball fight!
 
-#org @gText_Memory_LabDiscovery
+#org @gText_Memory_9
 Strange Lab Discovery
 
+#org @gText_Memory_10
+10
+
+#org @gText_Memory_11
+11
+
+#org @gText_Memory_12
+12
+
+#org @gText_Memory_13
+13
+
+#org @gText_Memory_14
+14
+
+#org @gText_Memory_15
+Serenade in the Safari
+
+#org @gText_Memory_16
+16
+
+#org @gText_Memory_17
+17
+
+#org @gText_Memory_18
+18
+
+#org @gText_Memory_19
+19
+
+#org @gText_Memory_20
+20
+
+#org @gText_Memory_21
+21
+
+#org @gText_Memory_22
+22
+
+#org @gText_Memory_23
+23
+
+#org @gText_Memory_24
+24
+
+#org @gText_Memory_25
+25
+
+#org @gText_Memory_26
+26
+
+#org @gText_Memory_27
+27
+
+#org @gText_Memory_28
+28
+
+#org @gText_Memory_29
+29
+
+#org @gText_Memory_30
+30
+
+#org @gText_Memory_31
+31
+
+#org @gText_Memory_32
+32
+
+#org @gText_Memory_33
+33
+
+#org @gText_Memory_34
+34
+
+#org @gText_Memory_35
+35
+
+#org @gText_Memory_36
+36
+
+#org @gText_Memory_37
+37
+
+#org @gText_Memory_38
+38
+
+#org @gText_Memory_39
+39
+
+#org @gText_Memory_40
+40
+
+#org @gText_Memory_41
+41
+
+#org @gText_Memory_42
+42
+
+#org @gText_Memory_43
+43
+
 // Memory Descriptions
-#org @gText_MemoryDesc_MeloettaUnderTree
- You meet Meloetta under a tree! You and\n her eat some berries.
+#org @gText_Desc_None
+ No description available
 
-#org @gText_MemoryDesc_PikachuAndEevee
- Pikachu plays with Eevee and\n become best friends!
+#org @gText_MemoryDesc_1
+ You meet Professor Oak and he\n gives you your Kanto partner!
 
-#org @gText_MemoryDesc_InsideCave
- You enter the Mt. Moon and\n find the Moon stone!
+#org @gText_MemoryDesc_2
+ Meloetta sings a prelude in the\n Pok\ePark with you!
 
-#org @gText_MemoryDesc_NightSkyWish
+#org @gText_MemoryDesc_3
+ Meloetta and you admire the sunset at\n the harbour footbridge.
+
+#org @gText_MemoryDesc_4
  You close your eyes and wish on\n a shooting star in the night sky.
 
-#org @gText_MemoryDesc_SeasideShells
+#org @gText_MemoryDesc_5
  You collect colorful shells while\n walking along the calm beach.
 
-#org @gText_MemoryDesc_CampfireTales
+#org @gText_MemoryDesc_6
  You and your Pok\emon sit by a\n campfire and share spooky tales.
 
-#org @gText_MemoryDesc_SakuraPath
- Petals fall like snow as you walk\n down the cherry blossom trail.
+#org @gText_MemoryDesc_7
+ Meloetta takes a look at her\n favourite spot- the Autumn tree!
 
-#org @gText_MemoryDesc_SnowballFight
+#org @gText_MemoryDesc_8
  You have a friendly snowball fight\n with a Sneasel and your partner.
 
-#org @gText_MemoryDesc_LabDiscovery
+#org @gText_MemoryDesc_9
  You discover old notes in a\n forgotten lab about Mega Evolution.
+
+#org @gText_MemoryDesc_10
+ 10th Memory
+
+#org @gText_MemoryDesc_11
+ 11th Memory
+
+#org @gText_MemoryDesc_12
+ 12th Memory
+
+#org @gText_MemoryDesc_13
+ 13th Memory
+
+#org @gText_MemoryDesc_14
+ 14th Memory
+
+#org @gText_MemoryDesc_15
+ A memory of your first visit to the\n Safari Zone with Meloetta.
+
+#org @gText_MemoryDesc_16
+ 16th Memory
+
+#org @gText_MemoryDesc_17
+ 17th Memory
+
+#org @gText_MemoryDesc_18
+ 18th Memory
+
+#org @gText_MemoryDesc_19
+ 19th Memory
+
+#org @gText_MemoryDesc_20
+ 20th Memory
+
+#org @gText_MemoryDesc_21
+ 21st Memory
+
+#org @gText_MemoryDesc_22
+ 22nd Memory
+
+#org @gText_MemoryDesc_23
+ 23rd Memory
+
+#org @gText_MemoryDesc_24
+ 24th Memory
+
+#org @gText_MemoryDesc_25
+ 25th Memory
+
+#org @gText_MemoryDesc_26
+ 26th Memory
+
+#org @gText_MemoryDesc_27
+ 27th Memory
+
+#org @gText_MemoryDesc_28
+ 28th Memory
+
+#org @gText_MemoryDesc_29
+ 29th Memory
+
+#org @gText_MemoryDesc_30
+ 30th Memory
+
+#org @gText_MemoryDesc_31
+ 31st Memory
+
+#org @gText_MemoryDesc_32
+ 32nd Memory
+
+#org @gText_MemoryDesc_33
+ 33rd Memory
+
+#org @gText_MemoryDesc_34
+ 34th Memory
+
+#org @gText_MemoryDesc_35
+ 35th Memory
+
+#org @gText_MemoryDesc_36
+ 36th Memory
+
+#org @gText_MemoryDesc_37
+ 37th Memory
+
+#org @gText_MemoryDesc_38
+ 38th Memory
+
+#org @gText_MemoryDesc_39
+ 39th Memory
+
+#org @gText_MemoryDesc_40
+ 40th Memory
+
+#org @gText_MemoryDesc_41
+ 41st Memory
+
+#org @gText_MemoryDesc_42
+ 42nd Memory
+
+#org @gText_MemoryDesc_43
+ 43rd Memory
+
+#org @gText_AlbumFlagSet
+Flags set!


### PR DESCRIPTION
## Summary
- Track the first displayed memory in the album screen to avoid unnecessary redraws
- Only rerender memory names when the visible list changes for smoother scrolling

## Testing
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_689702cf464483208d829933ca4e3382