### PR TITLE
Add bonus album page with R/L navigation

### DIFF
--- a/include/new/album.h
+++ b/include/new/album.h
@@ -3,6 +3,8 @@
 #include "../global.h"
 
 #define MEMORIES_COUNT 9
+#define BONUS_MEMORIES_COUNT 5
+#define TOTAL_MEMORIES_COUNT (MEMORIES_COUNT + BONUS_MEMORIES_COUNT)
 #define sAlbumPtr (*((struct Album**) 0x203E038))
 #define BG_MAP_BYTES 0x800
 #define ALBUM_MEMORIES_PER_PAGE 7
@@ -28,6 +30,13 @@ enum AlbumBGs
     BG_BACKGROUND,
 };
 
+enum AlbumPages
+{
+    ALBUM_PAGE_MEMORIES,
+    ALBUM_PAGE_BONUS,
+    ALBUM_PAGE_COUNT,
+};
+
 struct Memory
 {
     bool8 unlocked;
@@ -41,11 +50,12 @@ struct Album
     u16* bgMap;
 
     // Memory Data
-    struct Memory memoryData[MEMORIES_COUNT + 2];
+    struct Memory memoryData[TOTAL_MEMORIES_COUNT];
 
     // Tracker Data
-    u8 selectedMemory;
-    u8 selectedMemoryInAlbum; // Max of 7
+    u8 selectedMemory[ALBUM_PAGE_COUNT];
+    u8 selectedMemoryInAlbum[ALBUM_PAGE_COUNT]; // Max of 7
+    u8 page;
 };
 
 static const struct TextColor sWhiteText =
@@ -62,6 +72,7 @@ extern const u16 AlbumBGPal[];
 
 /* ============= Text Declarations ============== */
 extern const u8 gText_AlbumHeader[];
+extern const u8 gText_BonusHeader[];
 
 // Memory Names
 extern const u8 gText_Memory_MeloettaUnderTree[];
@@ -74,6 +85,13 @@ extern const u8 gText_Memory_SakuraPath[];
 extern const u8 gText_Memory_SnowballFight[];
 extern const u8 gText_Memory_LabDiscovery[];
 
+// Bonus Memory Names
+extern const u8 gText_Bonus_MysteryEncounter[];
+extern const u8 gText_Bonus_LegendaryMeeting[];
+extern const u8 gText_Bonus_SecretBase[];
+extern const u8 gText_Bonus_SkyCruise[];
+extern const u8 gText_Bonus_AncientPuzzle[];
+
 // Memory Descriptions
 extern const u8 gText_MemoryDesc_MeloettaUnderTree[];
 extern const u8 gText_MemoryDesc_PikachuAndEevee[];
@@ -84,6 +102,13 @@ extern const u8 gText_MemoryDesc_CampfireTales[];
 extern const u8 gText_MemoryDesc_SakuraPath[];
 extern const u8 gText_MemoryDesc_SnowballFight[];
 extern const u8 gText_MemoryDesc_LabDiscovery[];
+
+// Bonus Memory Descriptions
+extern const u8 gText_BonusDesc_MysteryEncounter[];
+extern const u8 gText_BonusDesc_LegendaryMeeting[];
+extern const u8 gText_BonusDesc_SecretBase[];
+extern const u8 gText_BonusDesc_SkyCruise[];
+extern const u8 gText_BonusDesc_AncientPuzzle[];
 
 // Script call
 extern const u8 EventScript_AlbumMemorySelected[];

--- a/src/album.c
+++ b/src/album.c
@@ -171,6 +171,22 @@ static void InitAlbumData(void)
 
     sAlbumPtr->memoryData[8].memoryName = gText_Memory_LabDiscovery;
     sAlbumPtr->memoryData[8].memoryDesc = gText_MemoryDesc_LabDiscovery;
+
+    // Bonus memories
+    sAlbumPtr->memoryData[9].memoryName = gText_Bonus_MysteryEncounter;
+    sAlbumPtr->memoryData[9].memoryDesc = gText_BonusDesc_MysteryEncounter;
+
+    sAlbumPtr->memoryData[10].memoryName = gText_Bonus_LegendaryMeeting;
+    sAlbumPtr->memoryData[10].memoryDesc = gText_BonusDesc_LegendaryMeeting;
+
+    sAlbumPtr->memoryData[11].memoryName = gText_Bonus_SecretBase;
+    sAlbumPtr->memoryData[11].memoryDesc = gText_BonusDesc_SecretBase;
+
+    sAlbumPtr->memoryData[12].memoryName = gText_Bonus_SkyCruise;
+    sAlbumPtr->memoryData[12].memoryDesc = gText_BonusDesc_SkyCruise;
+
+    sAlbumPtr->memoryData[13].memoryName = gText_Bonus_AncientPuzzle;
+    sAlbumPtr->memoryData[13].memoryDesc = gText_BonusDesc_AncientPuzzle;
 }
 
 static void DisplayAlbumBG(void)
@@ -190,7 +206,7 @@ static void DisplayAlbumBG(void)
 
 static void PrintGUIAlbumHeader(void)
 {
-    const u8* text = gText_AlbumHeader;
+    const u8* text = (sAlbumPtr->page == ALBUM_PAGE_BONUS) ? gText_BonusHeader : gText_AlbumHeader;
     u8 fontSize = 1; // Normal text
     CleanWindow(WIN_ALBUM_HEADER);
 
@@ -199,19 +215,31 @@ static void PrintGUIAlbumHeader(void)
     CommitWindow(WIN_ALBUM_HEADER);
 }
 
+static u8 GetPageOffset(void)
+{
+    return (sAlbumPtr->page == ALBUM_PAGE_BONUS) ? MEMORIES_COUNT : 0;
+}
+
+static u8 GetMemoryCount(void)
+{
+    return (sAlbumPtr->page == ALBUM_PAGE_BONUS) ? BONUS_MEMORIES_COUNT : MEMORIES_COUNT;
+}
+
 static void PrintGUIAlbumMemoryNames(void)
 {
     u8 fontSize = 1; // Normal Text
     u8 y = 0;
+    u8 page = sAlbumPtr->page;
 
-    u8 startId = sAlbumPtr->selectedMemory - sAlbumPtr->selectedMemoryInAlbum;
+    u8 startId = sAlbumPtr->selectedMemory[page] - sAlbumPtr->selectedMemoryInAlbum[page];
+    u16 base = GetPageOffset();
 
     CleanWindow(WIN_ALBUM_MEMORY_NAME);
 
-    for (u8 i = 0; i < ALBUM_MEMORIES_PER_PAGE && (startId + i) < MEMORIES_COUNT; ++i)
+    for (u8 i = 0; i < ALBUM_MEMORIES_PER_PAGE && (startId + i) < GetMemoryCount(); ++i)
     {
         WindowPrint(WIN_ALBUM_MEMORY_NAME, fontSize, 0, y, &sWhiteText, 0,
-                   sAlbumPtr->memoryData[startId + i].memoryName);
+                   sAlbumPtr->memoryData[base + startId + i].memoryName);
         y += 16;
     }
 
@@ -223,7 +251,9 @@ static void PrintGUIAlbumDescription(void)
     u8 fontSize = 1;
     u8 x = 0;
     u8 y = 0;
-    u8 memoryId = sAlbumPtr->selectedMemory;
+    u8 page = sAlbumPtr->page;
+    u16 base = GetPageOffset();
+    u16 memoryId = base + sAlbumPtr->selectedMemory[page];
 
     CleanWindow(WIN_ALBUM_MEMORY_DESC);
     WindowPrint(WIN_ALBUM_MEMORY_DESC, fontSize, x, y, &sWhiteText, 0,
@@ -236,9 +266,10 @@ static void UpdateCursorHighlight(bool8 isKeyUp, bool8 isStartUp)
     const u16* romPal = AlbumBGPal;
     u16* pal = gPlttBufferFaded;
     u16 defaultPal = romPal[7];
+    u8 page = sAlbumPtr->page;
 
     // Change the palette
-    u8 newIndex = sAlbumPtr->selectedMemoryInAlbum;
+    u8 newIndex = sAlbumPtr->selectedMemoryInAlbum[page];
     u8 palId = newIndex + 7;
 
     // Restore previous highlighted palette
@@ -321,17 +352,18 @@ static void Task_AlbumShowImage(u8 taskId)
 static void Task_AlbumWaitForKeyPress(u8 taskId)
 {
     bool8 scrolled = FALSE;
+    u8 page = sAlbumPtr->page;
 
     if (gMain.newKeys & DPAD_DOWN)
     {
-        if (sAlbumPtr->selectedMemory < MEMORIES_COUNT - 1)
+        if (sAlbumPtr->selectedMemory[page] < GetMemoryCount() - 1)
         {
-            sAlbumPtr->selectedMemory++;
+            sAlbumPtr->selectedMemory[page]++;
 
-            if (sAlbumPtr->selectedMemoryInAlbum < ALBUM_MEMORIES_PER_PAGE - 1 &&
-                sAlbumPtr->selectedMemoryInAlbum < MEMORIES_COUNT - 1)
+            if (sAlbumPtr->selectedMemoryInAlbum[page] < ALBUM_MEMORIES_PER_PAGE - 1 &&
+                sAlbumPtr->selectedMemoryInAlbum[page] < GetMemoryCount() - 1)
             {
-                sAlbumPtr->selectedMemoryInAlbum++;
+                sAlbumPtr->selectedMemoryInAlbum[page]++;
             }
 
             UpdateCursorHighlight(FALSE, FALSE);
@@ -340,13 +372,13 @@ static void Task_AlbumWaitForKeyPress(u8 taskId)
     }
     else if (gMain.newKeys & DPAD_UP)
     {
-        if (sAlbumPtr->selectedMemory > 0)
+        if (sAlbumPtr->selectedMemory[page] > 0)
         {
-            sAlbumPtr->selectedMemory--;
+            sAlbumPtr->selectedMemory[page]--;
 
-            if (sAlbumPtr->selectedMemoryInAlbum > 0)
+            if (sAlbumPtr->selectedMemoryInAlbum[page] > 0)
             {
-                sAlbumPtr->selectedMemoryInAlbum--;
+                sAlbumPtr->selectedMemoryInAlbum[page]--;
             }
 
             UpdateCursorHighlight(TRUE, FALSE);
@@ -362,11 +394,29 @@ static void Task_AlbumWaitForKeyPress(u8 taskId)
         PlaySE(SE_SELECT);
     }
 
+    if (gMain.newKeys & R_BUTTON && page == ALBUM_PAGE_MEMORIES)
+    {
+        sAlbumPtr->page = ALBUM_PAGE_BONUS;
+        LoadPalette(AlbumBGPal, 0, 0x20);
+        PrintGUIAlbumItems();
+        UpdateCursorHighlight(FALSE, TRUE);
+        return;
+    }
+
+    if (gMain.newKeys & L_BUTTON && page == ALBUM_PAGE_BONUS)
+    {
+        sAlbumPtr->page = ALBUM_PAGE_MEMORIES;
+        LoadPalette(AlbumBGPal, 0, 0x20);
+        PrintGUIAlbumItems();
+        UpdateCursorHighlight(FALSE, TRUE);
+        return;
+    }
+
     if (gMain.newKeys & A_BUTTON)
     {
         PlaySE(SE_SELECT);
-        VarSet(VAR_ALBUM_SELECTED_MEMORY, sAlbumPtr->selectedMemory);
-        VarSet(VAR_ALBUM_SELECTED_MEMORY_IN_ALBUM, sAlbumPtr->selectedMemoryInAlbum);
+        VarSet(VAR_ALBUM_SELECTED_MEMORY, GetPageOffset() + sAlbumPtr->selectedMemory[page]);
+        VarSet(VAR_ALBUM_SELECTED_MEMORY_IN_ALBUM, sAlbumPtr->selectedMemoryInAlbum[page]);
         BeginNormalPaletteFade(0xFFFFFFFF, 0, 0, 16, RGB_BLACK);
         gTasks[taskId].func = Task_AlbumShowImage;
     }
@@ -403,11 +453,15 @@ static void InitAlbum(void)
     CleanWindows();
     CommitWindows();
 
-    // Restore the last selected memory and cursor position
-    sAlbumPtr->selectedMemory = VarGet(VAR_ALBUM_SELECTED_MEMORY);
-    sAlbumPtr->selectedMemoryInAlbum = VarGet(VAR_ALBUM_SELECTED_MEMORY_IN_ALBUM);
-
     InitAlbumData();
+
+    // Restore the last selected memory and cursor position
+    sAlbumPtr->selectedMemory[ALBUM_PAGE_MEMORIES] = VarGet(VAR_ALBUM_SELECTED_MEMORY);
+    sAlbumPtr->selectedMemoryInAlbum[ALBUM_PAGE_MEMORIES] = VarGet(VAR_ALBUM_SELECTED_MEMORY_IN_ALBUM);
+    sAlbumPtr->selectedMemory[ALBUM_PAGE_BONUS] = 0;
+    sAlbumPtr->selectedMemoryInAlbum[ALBUM_PAGE_BONUS] = 0;
+    sAlbumPtr->page = ALBUM_PAGE_MEMORIES;
+
     PrintGUIAlbumItems();
 }
 

--- a/strings/album_strings.string
+++ b/strings/album_strings.string
@@ -1,6 +1,9 @@
 #org @gText_AlbumHeader
 Memories
 
+#org @gText_BonusHeader
+Bonus
+
 
 // Memory Names
 #org @gText_Memory_MeloettaUnderTree
@@ -30,6 +33,22 @@ Snowball fight!
 #org @gText_Memory_LabDiscovery
 Strange Lab Discovery
 
+// Bonus Memory Names
+#org @gText_Bonus_MysteryEncounter
+Mystery Encounter
+
+#org @gText_Bonus_LegendaryMeeting
+Legendary Meeting
+
+#org @gText_Bonus_SecretBase
+Secret Base Discovery
+
+#org @gText_Bonus_SkyCruise
+Sky Cruise
+
+#org @gText_Bonus_AncientPuzzle
+Ancient Puzzle
+
 // Memory Descriptions
 #org @gText_MemoryDesc_MeloettaUnderTree
  You meet Meloetta under a tree! You and\n her eat some berries.
@@ -57,3 +76,18 @@ Strange Lab Discovery
 
 #org @gText_MemoryDesc_LabDiscovery
  You discover old notes in a\n forgotten lab about Mega Evolution.
+
+#org @gText_BonusDesc_MysteryEncounter
+ You meet a wandering Celebi who\n shows you visions of the past.
+
+#org @gText_BonusDesc_LegendaryMeeting
+ You bump into Mewtwo deep inside\n Cerulean Cave.
+
+#org @gText_BonusDesc_SecretBase
+ You discover a hidden base filled\n with dazzling treasures.
+
+#org @gText_BonusDesc_SkyCruise
+ You soar through the clouds on\n the back of a Dragonite.
+
+#org @gText_BonusDesc_AncientPuzzle
+ You solve a long-forgotten puzzle\n and awaken a giant Regigigas.


### PR DESCRIPTION
## Summary
- Add bonus album page toggled with R/L buttons and tracked cursor
- Populate five placeholder bonus memories with descriptions
- Update album text strings and data structures for multi-page support

## Testing
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_68984ee2b5f08320b13cf46cab11c119