### PR TITLE
Remove redundant album memory structure

### DIFF
--- a/include/new/album.h
+++ b/include/new/album.h
@@ -50,7 +50,7 @@ struct Album
     u16* bgMap;
 
     // Memory Data
-    bool8 unlocked[MEMORIES_COUNT + BONUS_MEMORIES_COUNT + 2];
+    bool8 unlocked[MEMORIES_COUNT];
 
     // Tracker Data
     u8 selectedMemory;
@@ -185,6 +185,7 @@ extern const u8 gText_BonusPageInstructions[];
 // Memories unlocked
 extern const u8 gText_AlbumMemoriesUnlocked[];
 
+extern const u8 CallScript_Album[];
 struct ImageData 
 {
     u8 *tiles;

--- a/include/new/album.h
+++ b/include/new/album.h
@@ -44,20 +44,13 @@ enum AlbumBGs
     BG_BACKGROUND,
 };
 
-struct Memory
-{
-    bool8 unlocked;
-    const u8* memoryName;
-    const u8* memoryDesc;
-};
-
 struct Album
 {
     // Image Data
     u16* bgMap;
 
     // Memory Data
-    struct Memory memoryData[MEMORIES_COUNT + BONUS_MEMORIES_COUNT + 2];
+    bool8 unlocked[MEMORIES_COUNT + BONUS_MEMORIES_COUNT + 2];
 
     // Tracker Data
     u8 selectedMemory;

--- a/src/album.c
+++ b/src/album.c
@@ -10,7 +10,7 @@
 #include "../include/field_weather.h"
 #include "../include/fieldmap.h"
 #include "../include/gpu_regs.h"
-#include "../include/international_string_util.h"
+#include "../include/string_util.h"
 #include "../include/item_menu.h"
 #include "../include/map_name_popup.h"
 #include "../include/menu.h"
@@ -235,16 +235,7 @@ static void InitAlbumData(bool8 bonusPage)
     for (u8 i = 0; i < count; i++)
     {
         u8 imageIndex = table[i].imageIndex;
-
-        if (bonusPage)
-        {
-            sAlbumPtr->unlocked[i] = TRUE;
-        }
-        else
-        {
-            bool8 unlocked = (imageIndex > 0 && imageIndex <= 38) ? FlagGet(FLAG_FIRST_MEMORY + imageIndex) : TRUE;
-            sAlbumPtr->unlocked[i] = unlocked;
-        }
+        sAlbumPtr->unlocked[i] = FlagGet(FLAG_FIRST_MEMORY + imageIndex) ? TRUE : FALSE;
     }
 }
 
@@ -337,7 +328,6 @@ static void PrintGUIAlbumMemoriesUnlocked(void)
     for (u8 i = 0; i < sAlbumPtr->memoryCount; ++i)
         if (sAlbumPtr->unlocked[i])
             unlocked++;
-
 
     CleanWindow(WIN_ALBUM_MEMORIES_COUNT);
 
@@ -444,6 +434,7 @@ static void Task_AlbumFadeOut(u8 taskId)
 {
     if (!gPaletteFade->active)
     {
+        Overworld_ChangeMusicToDefault();
         SetMainCallback2(CB2_ReturnToFieldWithOpenMenu);
         Free(sAlbumPtr->bgMap);
         Free(sAlbumPtr);
@@ -743,6 +734,7 @@ bool8 StartMenuAlbumCallback(void)
 {
     if (!gPaletteFade->active)
     {
+        FadeOutAndPlayNewMapMusic(0x194, 0x5);
         CleanWindows();
         PlayRainStoppingSoundEffect();
         DestroySafariZoneStatsWindow();

--- a/src/album.c
+++ b/src/album.c
@@ -235,22 +235,15 @@ static void InitAlbumData(bool8 bonusPage)
     for (u8 i = 0; i < count; i++)
     {
         u8 imageIndex = table[i].imageIndex;
-        sAlbumPtr->memoryData[i].memoryName = table[i].name;
-        sAlbumPtr->memoryData[i].memoryDesc = table[i].desc;
 
         if (bonusPage)
         {
-            sAlbumPtr->memoryData[i].unlocked = TRUE;
+            sAlbumPtr->unlocked[i] = TRUE;
         }
         else
         {
             bool8 unlocked = (imageIndex > 0 && imageIndex <= 38) ? FlagGet(FLAG_FIRST_MEMORY + imageIndex) : TRUE;
-            sAlbumPtr->memoryData[i].unlocked = unlocked;
-            if (!unlocked)
-            {
-                sAlbumPtr->memoryData[i].memoryName = gText_None;
-                sAlbumPtr->memoryData[i].memoryDesc = gText_Desc_None;
-            }
+            sAlbumPtr->unlocked[i] = unlocked;
         }
     }
 }
@@ -307,13 +300,14 @@ static void PrintGUIAlbumMemoryNames(void)
     u8 fontSize = 1; // Normal Text
     u8 y = 0;
     u8 startId = sAlbumPtr->displayedStartId;
+    const struct MemoryEntry *table = sAlbumPtr->isBonusPage ? sBonusMemoryTable : sMemoryTable;
 
     CleanWindow(WIN_ALBUM_MEMORY_NAME);
 
     for (u8 i = 0; i < ALBUM_MEMORIES_PER_PAGE && (startId + i) < sAlbumPtr->memoryCount; ++i)
     {
-        WindowPrint(WIN_ALBUM_MEMORY_NAME, fontSize, 0, y, &sWhiteText, 0,
-                   sAlbumPtr->memoryData[startId + i].memoryName);
+        const u8 *name = sAlbumPtr->unlocked[startId + i] ? table[startId + i].name : gText_None;
+        WindowPrint(WIN_ALBUM_MEMORY_NAME, fontSize, 0, y, &sWhiteText, 0, name);
         y += 16;
     }
 
@@ -326,10 +320,11 @@ static void PrintGUIAlbumDescription(void)
     u8 x = 0;
     u8 y = 0;
     u8 memoryId = sAlbumPtr->selectedMemory;
+    const struct MemoryEntry *table = sAlbumPtr->isBonusPage ? sBonusMemoryTable : sMemoryTable;
 
     CleanWindow(WIN_ALBUM_MEMORY_DESC);
-    WindowPrint(WIN_ALBUM_MEMORY_DESC, fontSize, x, y, &sWhiteText, 0,
-                   sAlbumPtr->memoryData[memoryId].memoryDesc);
+    const u8 *desc = sAlbumPtr->unlocked[memoryId] ? table[memoryId].desc : gText_Desc_None;
+    WindowPrint(WIN_ALBUM_MEMORY_DESC, fontSize, x, y, &sWhiteText, 0, desc);
     CommitWindow(WIN_ALBUM_MEMORY_DESC);
 }
 
@@ -340,7 +335,7 @@ static void PrintGUIAlbumMemoriesUnlocked(void)
 
     // Count unlocked memories for the current page
     for (u8 i = 0; i < sAlbumPtr->memoryCount; ++i)
-        if (sAlbumPtr->memoryData[i].unlocked)
+        if (sAlbumPtr->unlocked[i])
             unlocked++;
 
 
@@ -591,7 +586,7 @@ static void Task_AlbumWaitForKeyPress(u8 taskId)
             VarSet(VAR_ALBUM_BONUS_DISPLAYED_START_ID,         sAlbumPtr->bonusDisplayedStartId);
         }
 
-        if (sAlbumPtr->memoryData[sAlbumPtr->selectedMemory].unlocked)
+        if (sAlbumPtr->unlocked[sAlbumPtr->selectedMemory])
         {
             BeginNormalPaletteFade(0xFFFFFFFF, 0, 0, 16, RGB_BLACK);
             PlaySE(SE_SELECT);

--- a/strings/ability_descriptions.string
+++ b/strings/ability_descriptions.string
@@ -14,7 +14,7 @@ Keeps user and allies awake.
 Multi-hit moves hit five times.
 
 #org @DESC_MOTORDRIVE
-Turns electricity into Speed.
+Turns electricity into speed.
 
 #org @DESC_MULTISCALE
 Reduces damage at full HP.

--- a/strings/ability_descriptions.string
+++ b/strings/ability_descriptions.string
@@ -14,7 +14,7 @@ Keeps user and allies awake.
 Multi-hit moves hit five times.
 
 #org @DESC_MOTORDRIVE
-Turns electricity into speed.
+Turns electricity into Speed.
 
 #org @DESC_MULTISCALE
 Reduces damage at full HP.

--- a/strings/album_strings.string
+++ b/strings/album_strings.string
@@ -36,7 +36,7 @@ A lovely album capturing your journey\nwith Meloetta.
 -
 
 #org @gText_Memory_1
-1
+Bonus Image 1
 
 #org @gText_Memory_2
 A Pok\ePark Cadence
@@ -45,263 +45,263 @@ A Pok\ePark Cadence
 Ballad by the Sunset Bay
 
 #org @gText_Memory_4
-4
+Sentinel of Vedeo
 
 #org @gText_Memory_5
-5
+Bonus Image 10
 
 #org @gText_Memory_6
-6
+A Relic Song
 
 #org @gText_Memory_7
 Where the leaves first fell
 
 #org @gText_Memory_8
-8
+White Flame's Judgement
 
 #org @gText_Memory_9
-9
+Black Storm's Wrath
 
 #org @gText_Memory_10
 10
 
 #org @gText_Memory_11
-11
+Bonus Image 5
 
 #org @gText_Memory_12
-12
-
-#org @gText_Memory_13
-13
-
-#org @gText_Memory_14
-14
-
-#org @gText_Memory_15
 Serenade in the Safari
 
+#org @gText_Memory_13
+Bonus Image 9
+
+#org @gText_Memory_14
+A Melody in the Woods
+
+#org @gText_Memory_15
+Bonus Image 2
+
 #org @gText_Memory_16
-16
+Bonus Image 6
 
 #org @gText_Memory_17
-17
+Bonus Image 8
 
 #org @gText_Memory_18
-18
+Bonus Image 7
 
 #org @gText_Memory_19
-19
+Bonus Image 4
 
 #org @gText_Memory_20
-20
+Bonus Image 3
 
 #org @gText_Memory_21
-21
+Hand in Hand - 1
 
 #org @gText_Memory_22
-22
+Hand in Hand - 2
 
 #org @gText_Memory_23
-23
+Perfect Challenger
 
 #org @gText_Memory_24
-24
+Nightmare's Shadow
 
 #org @gText_Memory_25
-25
+Good-Morning Duet
 
 #org @gText_Memory_26
-26
+Fighting Badge!
 
 #org @gText_Memory_27
-27
+Hello Riffrock!
 
 #org @gText_Memory_28
-28
+Fairy Badge!
 
 #org @gText_Memory_29
-29
+Dragon Badge!
 
 #org @gText_Memory_30
-30
+Wings of Winter
 
 #org @gText_Memory_31
-31
+Lightning's Fury
 
 #org @gText_Memory_32
-32
+Flames of the Legend
 
 #org @gText_Memory_33
-33
+Serpent of the Clouds
 
 #org @gText_Memory_34
-34
+Ghost Badge!
 
 #org @gText_Memory_35
-35
+Dark Badge!
 
 #org @gText_Memory_36
-36
+Grass Badge!
 
 #org @gText_Memory_37
-37
+Water Badge!
 
 #org @gText_Memory_38
-38
+Fire Badge!
 
 #org @gText_Memory_39
-39
+Lullaby of the Stars
 
 #org @gText_Memory_40
-40
+The Final Challenge Awaits!
 
 #org @gText_Memory_41
-41
+Boo!
 
 #org @gText_Memory_42
-42
+The Awakening
 
 #org @gText_Memory_43
-43
+Hey, wake up!
 
 #org @gText_Memory_44
-44
+Bonus Image 11
 
 // Memory Descriptions
 #org @gText_Desc_None
  No description available
 
 #org @gText_MemoryDesc_1
- 1st Memory
+ Which one will you choose?
 
 #org @gText_MemoryDesc_2
- Meloetta sings a prelude in the\n Pok\ePark with you!
+ Meloetta sings a lovely prelude\n in the Pok\ePark!
 
 #org @gText_MemoryDesc_3
  Meloetta and you admire the sunset at\n the harbour footbridge.
 
 #org @gText_MemoryDesc_4
- 4th Memory
+Beneath the towering summit of Mt. Relic,\na new chapter in the adventure begins.
 
 #org @gText_MemoryDesc_5
- 5th Memory
+ I wonder if there are more Pok\emon\n out in space[.]
 
 #org @gText_MemoryDesc_6
- 6th Memory
+ Meloetta unlocks the secret door in\n the Ruins with her melodius voice.
 
 #org @gText_MemoryDesc_7
- Meloetta takes a look at her\n favourite spot- the Autumn tree!
+ Meloetta takes a look at her favourite\n spot- the Autumn tree!
 
 #org @gText_MemoryDesc_8
- 8th Memory
+ Wreathed in fire, Reshiram challenges\n all those who walk the path of truth.
 
 #org @gText_MemoryDesc_9
- 9th Memory
+ Cloaked in lightning, Zekrom confronts\n all those who dare to defy its vision.
 
 #org @gText_MemoryDesc_10
  10th Memory
 
 #org @gText_MemoryDesc_11
- 11th Memory
+ Mwaaahhhh!
 
 #org @gText_MemoryDesc_12
- 12th Memory
+ A memory of your first visit to the\n Safari Zone with Meloetta!
 
 #org @gText_MemoryDesc_13
- 13th Memory
+ Two legends next to each other.
 
 #org @gText_MemoryDesc_14
- 14th Memory
+Spiky Ear Pichu! A peaceful place where\nthe bond between friends grows stronger.
 
 #org @gText_MemoryDesc_15
- 15th Memory
+ Another difficult choice!
 
 #org @gText_MemoryDesc_16
- 16th Memory
+ Science, progress, Porygon-Z!
 
 #org @gText_MemoryDesc_17
- 17th Memory
+ Have you ever played Victory Fire?
 
 #org @gText_MemoryDesc_18
- 18th Memory
+ So many flowers[.]
 
 #org @gText_MemoryDesc_19
- 19th Memory
+ Pok\emon Center - We take care\n of your Pok\emon.
 
 #org @gText_MemoryDesc_20
- 20th Memory
+ Need some time to relax?\n Visit the Pok\emon Caf\e!
 
 #org @gText_MemoryDesc_21
- 21st Memory
+ Their journey's trials forged a bond as\n enduring as Meloetta's timeless song.
 
 #org @gText_MemoryDesc_22
- 22nd Memory
+ Their journey's trials forged a bond as\n enduring as Meloetta's timeless song.
 
 #org @gText_MemoryDesc_23
- 23rd Memory
+Mewtwo, the ultimate creation, breaks\nfree to challenge all who cross its path
 
 #org @gText_MemoryDesc_24
- 24th Memory
+ Darkrai emerges from the darkness,\n warping dreams into haunting visions.
 
 #org @gText_MemoryDesc_25
- 25th Memory
+ Your first duet with Meloetta!
 
 #org @gText_MemoryDesc_26
- 26th Memory
+ A symbol of victory earned by you\n and Meloetta in the Fighting Gym!
 
 #org @gText_MemoryDesc_27
- 27th Memory
+ What a lovely view from the ferry,\n gazing out toward Riffrock!
 
 #org @gText_MemoryDesc_28
- 28th Memory
+ A symbol of victory earned by you\n and Meloetta in the Fairy Gym!
 
 #org @gText_MemoryDesc_29
- 29th Memory
+ A symbol of victory earned by you\n and Meloetta in the Dragon Gym!
 
 #org @gText_MemoryDesc_30
- 30th Memory
+ In the heart of a snowstorm, Articuno\n descends to meet the brave duo.
 
 #org @gText_MemoryDesc_31
- 31st Memory
+ Zapdos crackles with power, the storm\n obeying its every command.
 
 #org @gText_MemoryDesc_32
- 32nd Memory
+ Moltres soars above, its fiery wings\n blazing a path in the sky.
 
 #org @gText_MemoryDesc_33
- 33rd Memory
+ High above the world, a fateful\n battle begins[.]
 
 #org @gText_MemoryDesc_34
- 34th Memory
+ A symbol of victory earned by you\n and Meloetta in the Ghost Gym!
 
 #org @gText_MemoryDesc_35
- 35th Memory
+ A symbol of victory earned by you\n and Meloetta in the Dark Gym!
 
 #org @gText_MemoryDesc_36
- 36th Memory
+ A symbol of victory earned by you\n and Meloetta in the Grass Gym!
 
 #org @gText_MemoryDesc_37
- 37th Memory
+ A symbol of victory earned by you\n and Meloetta in the Water Gym!
 
 #org @gText_MemoryDesc_38
- 38th Memory
+ A symbol of victory earned by you\n and Meloetta in the Fire Gym!
 
 #org @gText_MemoryDesc_39
- 39th Memory
+ She looks so peaceful with her eyes\n closed[.]
 
 #org @gText_MemoryDesc_40
- 40th Memory
+In the heart of Vedeo lies its Grand\nTrial - a true test of skill and courage.
 
 #org @gText_MemoryDesc_41
- 41st Memory
+ A friendly(?) ghost welcomes you\n to the Haunted Mansion!
 
 #org @gText_MemoryDesc_42
- 42nd Memory
+Buried in the Sandtone Desert, Regirock\nstirs as you disrupt its eternal slumber.
 
 #org @gText_MemoryDesc_43
- 43rd Memory
+ A concert with Meloetta[.] and maybe\n Snorlax on the Belly Drum?
 
 #org @gText_MemoryDesc_44
- 44th Memory
+ Thank you!
 
 #org @gText_AlbumFlagSet
 Flags set!


### PR DESCRIPTION
## Summary
- Replace unused `struct Memory` with a simple unlocked flag array in `struct Album`.
- Reference memory names and descriptions directly from static tables, removing duplicate assignments.

## Testing
- `make` *(fails: No targets specified and no makefile found)*
- `gcc -c src/album.c -I include -o /tmp/album.o` *(fails: warnings and object not produced)*

------
https://chatgpt.com/codex/tasks/task_e_6899e48df2c083208cb8a08f9ef89351